### PR TITLE
Remove import six from django.utils since its removed from django

### DIFF
--- a/drfreverseproxy/views.py
+++ b/drfreverseproxy/views.py
@@ -4,7 +4,7 @@ import mimetypes
 
 import urllib3
 
-from django.utils.six.moves.urllib.parse import urlparse, urlencode, quote_plus
+from six.moves.urllib.parse import urlparse, urlencode, quote_plus
 from django.shortcuts import redirect
 
 from rest_framework.views import APIView

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ mkdocs==0.11.1
 
 # Application dependencies
 urllib3==1.22
+six~=1.15.0

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,11 +4,10 @@ from mock import patch
 import os
 
 from django.test import TestCase, RequestFactory
-from django.utils.six.moves.urllib.parse import ParseResult
+from six.moves.urllib.parse import ParseResult
 
 from drfreverseproxy.exceptions import InvalidUpstream
 from drfreverseproxy.views import ProxyView
-
 from .utils import get_urlopen_mock
 
 
@@ -134,8 +133,8 @@ class ViewTest(TestCase):
             upstream = 'http://example.com'
 
             def get_proxy_request_headers(self, request):
-                headers = super(CustomProxyView, self).\
-                                get_proxy_request_headers(request)
+                headers = super(CustomProxyView, self). \
+                    get_proxy_request_headers(request)
                 headers['DNT'] = 1
                 return headers
 


### PR DESCRIPTION
I tried to use this package with Django > 3 but faced with the error that "django.utils" does not have "six" anymore. This PR is dedicated to fix that.

Thanks.